### PR TITLE
Improve PiP resizing, window responsiveness, and window controls

### DIFF
--- a/packages/app/src-tauri/Cargo.toml
+++ b/packages/app/src-tauri/Cargo.toml
@@ -75,6 +75,7 @@ mdns-sd = "0.19"
 windows = { version = "0.58", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
     "Win32_System_Threading",
     "Win32_Graphics_Gdi",
 ] }

--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -1,9 +1,238 @@
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Runtime, Manager};
 use log::{debug, info, warn, error};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::collections::HashMap;
 
+#[cfg(target_os = "windows")]
+mod pip_aspect_lock {
+    use std::sync::Mutex;
+    use windows::Win32::{
+        Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM},
+        UI::{
+            Shell::{DefSubclassProc, RemoveWindowSubclass, SetWindowSubclass},
+            WindowsAndMessaging::{GetWindowRect, WM_ENTERSIZEMOVE, WM_EXITSIZEMOVE, WM_SIZING,
+                WMSZ_BOTTOM, WMSZ_BOTTOMLEFT, WMSZ_BOTTOMRIGHT,
+                WMSZ_LEFT, WMSZ_RIGHT, WMSZ_TOP, WMSZ_TOPLEFT, WMSZ_TOPRIGHT},
+        },
+    };
+
+    const SUBCLASS_ID: usize = 0x594E_4F54;
+
+    #[derive(Clone, Copy)]
+    struct Size {
+        width: i32,
+        height: i32,
+    }
+
+    #[derive(Clone, Copy)]
+    enum Driver {
+        Width,
+        Height,
+    }
+
+    struct State {
+        ratio: Option<f64>,
+        start_size: Option<Size>,
+        corner_driver: Option<Driver>,
+    }
+
+    static STATE: Mutex<State> = Mutex::new(State {
+        ratio: None,
+        start_size: None,
+        corner_driver: None,
+    });
+
+    unsafe extern "system" fn window_proc(
+        hwnd: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+        _id: usize,
+        _data: usize,
+    ) -> LRESULT {
+        let sizing_result = if message == WM_SIZING {
+            Some(DefSubclassProc(hwnd, message, wparam, lparam))
+        } else {
+            None
+        };
+
+        if message == WM_ENTERSIZEMOVE {
+            if let Ok(mut state) = STATE.lock() {
+                let mut rect = RECT::default();
+                if GetWindowRect(hwnd, &mut rect).is_ok() {
+                    state.start_size = Some(Size {
+                        width: rect.right - rect.left,
+                        height: rect.bottom - rect.top,
+                    });
+                }
+                state.corner_driver = None;
+            }
+        } else if message == WM_EXITSIZEMOVE {
+            if let Ok(mut state) = STATE.lock() {
+                state.start_size = None;
+                state.corner_driver = None;
+            }
+        } else if message == WM_SIZING {
+            if let Ok(mut state) = STATE.lock() {
+                if let Some(ratio) = state.ratio {
+                let rect = &mut *(lparam.0 as *mut RECT);
+                let width = rect.right - rect.left;
+                let height = rect.bottom - rect.top;
+                let edge = wparam.0 as u32;
+
+                if matches!(edge, WMSZ_LEFT | WMSZ_RIGHT) {
+                    let target_height = (width as f64 / ratio).round() as i32;
+                    rect.bottom = rect.top + target_height;
+                } else if matches!(edge, WMSZ_TOP | WMSZ_BOTTOM) {
+                    let target_width = (height as f64 * ratio).round() as i32;
+                    rect.right = rect.left + target_width;
+                } else if matches!(edge, WMSZ_TOPLEFT | WMSZ_TOPRIGHT | WMSZ_BOTTOMLEFT | WMSZ_BOTTOMRIGHT) {
+                    if state.corner_driver.is_none() {
+                        let start = state.start_size.unwrap_or(Size { width, height });
+                        let width_change = (width - start.width).abs() as f64 / ratio;
+                        let height_change = (height - start.height).abs() as f64;
+                        state.corner_driver = Some(if height_change > width_change {
+                            Driver::Height
+                        } else {
+                            Driver::Width
+                        });
+                    }
+                    let driver = state.corner_driver.unwrap();
+
+                    if matches!(driver, Driver::Height) {
+                        let target_width = (height as f64 * ratio).round() as i32;
+                        if edge == WMSZ_TOPLEFT || edge == WMSZ_BOTTOMLEFT {
+                            rect.left = rect.right - target_width;
+                        } else {
+                            rect.right = rect.left + target_width;
+                        }
+                    } else {
+                        let target_height = (width as f64 / ratio).round() as i32;
+                        if edge == WMSZ_TOPLEFT || edge == WMSZ_TOPRIGHT {
+                            rect.top = rect.bottom - target_height;
+                        } else {
+                            rect.bottom = rect.top + target_height;
+                        }
+                    }
+                }
+                return LRESULT(1);
+                }
+            }
+        }
+        sizing_result.unwrap_or_else(|| DefSubclassProc(hwnd, message, wparam, lparam))
+    }
+
+    pub fn set(hwnd: HWND, ratio: Option<f64>) -> Result<(), String> {
+        {
+            let mut state = STATE.lock().map_err(|e| e.to_string())?;
+            state.ratio = ratio;
+            state.start_size = None;
+            state.corner_driver = None;
+        }
+        unsafe {
+            if ratio.is_some() {
+                if !SetWindowSubclass(hwnd, Some(window_proc), SUBCLASS_ID, 0).as_bool() {
+                    return Err("failed to install PiP window subclass".into());
+                }
+            } else {
+                let _ = RemoveWindowSubclass(hwnd, Some(window_proc), SUBCLASS_ID);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tauri::command]
+fn set_pip_aspect_lock(window: tauri::WebviewWindow, ratio: Option<f64>) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        let hwnd = window.hwnd().map_err(|e| e.to_string())?;
+        return pip_aspect_lock::set(
+            windows::Win32::Foundation::HWND(hwnd.0),
+            ratio.filter(|value| value.is_finite() && *value > 0.0),
+        );
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (window, ratio);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod resize_coalescing {
+    use windows::Win32::{
+        Foundation::{HWND, LPARAM, LRESULT, POINT, WPARAM},
+        UI::{
+            Shell::{DefSubclassProc, SetWindowSubclass},
+            WindowsAndMessaging::{
+                GetCursorPos, PeekMessageW, MSG, PM_REMOVE, WM_MOUSEMOVE, WM_SIZING,
+                WMSZ_BOTTOM, WMSZ_BOTTOMLEFT, WMSZ_BOTTOMRIGHT, WMSZ_LEFT, WMSZ_RIGHT,
+                WMSZ_TOP, WMSZ_TOPLEFT, WMSZ_TOPRIGHT,
+            },
+        },
+    };
+
+    const SUBCLASS_ID: usize = 0x594E_4F55;
+
+    unsafe extern "system" fn window_proc(
+        hwnd: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+        _id: usize,
+        _data: usize,
+    ) -> LRESULT {
+        if message == WM_SIZING {
+            let mut latest = None;
+            loop {
+                let mut pending = MSG::default();
+                if !PeekMessageW(
+                    &mut pending,
+                    HWND::default(),
+                    WM_MOUSEMOVE,
+                    WM_MOUSEMOVE,
+                    PM_REMOVE,
+                ).as_bool() {
+                    break;
+                }
+                latest = Some(pending);
+            }
+
+            if latest.is_some() {
+                let mut cursor = POINT::default();
+                if GetCursorPos(&mut cursor).is_ok() {
+                    let rect = &mut *(lparam.0 as *mut windows::Win32::Foundation::RECT);
+                    let edge = wparam.0 as u32;
+                    if matches!(edge, WMSZ_LEFT | WMSZ_TOPLEFT | WMSZ_BOTTOMLEFT) {
+                        rect.left = cursor.x;
+                    }
+                    if matches!(edge, WMSZ_RIGHT | WMSZ_TOPRIGHT | WMSZ_BOTTOMRIGHT) {
+                        rect.right = cursor.x;
+                    }
+                    if matches!(edge, WMSZ_TOP | WMSZ_TOPLEFT | WMSZ_TOPRIGHT) {
+                        rect.top = cursor.y;
+                    }
+                    if matches!(edge, WMSZ_BOTTOM | WMSZ_BOTTOMLEFT | WMSZ_BOTTOMRIGHT) {
+                        rect.bottom = cursor.y;
+                    }
+                }
+            }
+        }
+
+        DefSubclassProc(hwnd, message, wparam, lparam)
+    }
+
+    pub fn install(hwnd: HWND) -> Result<(), String> {
+        unsafe {
+            if !SetWindowSubclass(hwnd, Some(window_proc), SUBCLASS_ID, 0).as_bool() {
+                return Err("failed to install resize coalescing handler".into());
+            }
+        }
+        Ok(())
+    }
+}
 
 // macOS-specific imports for window configuration
 #[cfg(target_os = "macos")]
@@ -2948,8 +3177,6 @@ fn restore_window_position(app: &tauri::AppHandle) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 // ─── External Player State (for reuse / single-instance mode) ────────────────
 
-use std::sync::Mutex;
-
 pub struct ExternalPlayerState {
     pub pid: Mutex<Option<u32>>,
 }
@@ -3143,6 +3370,7 @@ pub fn run() {
             mpv_set_property,
             mpv_set_properties,
             mpv_get_property,
+            set_pip_aspect_lock,
             mpv_sync_window,
             mpv_set_geometry,
             mpv_kill,

--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -1107,23 +1107,35 @@ async fn mpv_get_params_debug<R: Runtime>(app: AppHandle<R>) -> Result<serde_jso
 }
 
 #[tauri::command]
-async fn mpv_toggle_fullscreen<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+async fn mpv_toggle_fullscreen<R: Runtime>(
+    app: AppHandle<R>,
+    restore_to_maximized: Option<bool>,
+) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("main") {
         let is_fullscreen = window.is_fullscreen().map_err(|e| e.to_string())?;
-        
-        // On Windows, if window is maximized and we're going fullscreen,
-        // we need to unmaximize first to ensure proper fullscreen transition
+        let should_restore_maximized = is_fullscreen && restore_to_maximized.unwrap_or(false);
+
         #[cfg(target_os = "windows")]
         if !is_fullscreen {
             let is_maximized = window.is_maximized().map_err(|e| e.to_string())?;
             if is_maximized {
                 window.unmaximize().map_err(|e| e.to_string())?;
-                // Small delay to let the window state settle before going fullscreen
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
         }
-        
+
+        #[cfg(target_os = "windows")]
+        if should_restore_maximized {
+            let _ = window.hide();
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
         window.set_fullscreen(!is_fullscreen).map_err(|e| e.to_string())?;
+
+        #[cfg(target_os = "windows")]
+        if should_restore_maximized {
+            window.maximize().map_err(|e| e.to_string())?;
+        }
         
         // On Windows, trigger a geometry refresh after entering fullscreen
         // to ensure MPV fills the entire screen
@@ -1131,6 +1143,10 @@ async fn mpv_toggle_fullscreen<R: Runtime>(app: AppHandle<R>) -> Result<(), Stri
         {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             let _ = mpv_windows::mpv_set_geometry(&app, 0, 0, 0, 0).await;
+            if should_restore_maximized {
+                let _ = window.show();
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
         }
         
         // On macOS, we need to sync the window after fullscreen change

--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -3228,6 +3228,12 @@ pub fn run() {
             #[cfg(target_os = "windows")]
             app.manage(SecondaryMpvState::new());
 
+            #[cfg(target_os = "windows")]
+            if let Some(window) = app.get_webview_window("main") {
+                let hwnd = window.hwnd().map_err(|e| e.to_string())?;
+                resize_coalescing::install(windows::Win32::Foundation::HWND(hwnd.0))?;
+            }
+
             // Configure macOS window for proper dragging with transparent titlebar
             #[cfg(target_os = "macos")]
             {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -87,6 +87,17 @@
   background: #e81123;
 }
 
+.window-control-icon {
+  display: block;
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1;
+  stroke-linecap: square;
+  shape-rendering: geometricPrecision;
+}
+
 /* Title Bar Layout - Using spacer pattern for centering */
 .title-bar-spacer {
   flex: 1;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -71,7 +71,7 @@ import { syncSource, syncVodForSource, isEpgStale, isVodStale, syncAllStaleGloba
 import { bulkOps } from './services/bulk-ops';
 import { Bridge, type AspectRatioMode, applyAspectRatio, rewriteTsToM3u8 } from './services/tauri-bridge';
 import { resolvePlayUrl } from './services/stream-resolver';
-import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
+import { currentMonitor, getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
 import { addToRecentChannels } from './utils/recentChannels';
 import { WatchlistNotificationContainer } from './components/WatchlistNotification';
 import { ToastContainer } from './components/Toast';
@@ -3122,11 +3122,27 @@ function App() {
         if (!window.storage) return;
         const result = await window.storage.getSettings();
         const settings = result.data || {};
-        const width = settings.startupWidth || 1920;
-        const height = settings.startupHeight || 1080;
+        const requestedWidth = settings.startupWidth || 1920;
+        const requestedHeight = settings.startupHeight || 1080;
 
         const appWindow = getCurrentWindow();
-        const isMaximized = await appWindow.isMaximized();
+        const [isMaximized, monitor, scaleFactor] = await Promise.all([
+          appWindow.isMaximized(),
+          currentMonitor(),
+          appWindow.scaleFactor(),
+        ]);
+
+        let width = requestedWidth;
+        let height = requestedHeight;
+
+        if (monitor) {
+          const maxWidth = monitor.size.width / scaleFactor;
+          const maxHeight = monitor.size.height / scaleFactor;
+          const fitScale = Math.min(maxWidth / requestedWidth, maxHeight / requestedHeight, 1);
+          width = Math.min(maxWidth, Math.max(960, Math.floor(requestedWidth * fitScale)));
+          height = Math.min(maxHeight, Math.max(600, Math.floor(requestedHeight * fitScale)));
+        }
+
         if (isMaximized) {
           await appWindow.unmaximize();
         }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1081,7 +1081,13 @@ function App() {
   // ==========================================================================
   // PiP (Picture-in-Picture) Mode
   // ==========================================================================
-  const pip = usePipMode();
+  const [pipAspectRatio, setPipAspectRatio] = useState<AspectRatioMode>(() => {
+    try {
+      const v = localStorage.getItem('ynotv_pip_aspect_ratio');
+      return (v as AspectRatioMode) || 'fit';
+    } catch { return 'fit'; }
+  });
+  const pip = usePipMode(pipAspectRatio);
   const { pipMode, pipControlsVisible, togglePip, showPipControls } = pip;
   const pipFromPreviewRef = useRef<{ categoriesOpen: boolean } | null>(null);
 
@@ -1447,13 +1453,6 @@ function App() {
   // ==========================================================================
   // PiP Aspect Ratio (independent from main / hero aspect ratio)
   // ==========================================================================
-  const [pipAspectRatio, setPipAspectRatio] = useState<AspectRatioMode>(() => {
-    try {
-      const v = localStorage.getItem('ynotv_pip_aspect_ratio');
-      return (v as AspectRatioMode) || 'fit';
-    } catch { return 'fit'; }
-  });
-
   // Persist & apply PiP aspect ratio
   const handleSetPipAspectRatio = useCallback(async (mode: AspectRatioMode) => {
     setPipAspectRatio(mode);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1628,7 +1628,7 @@ function App() {
   // ==========================================================================
   // Window Manager (from useWindowManager)
   // ==========================================================================
-  const { handleMinimize, handleMaximize, handleClose } = useWindowManager();
+  const { handleMinimize, handleMaximize, handleClose, isMaximized } = useWindowManager();
 
   // ==========================================================================
   // Update Modal State
@@ -3581,9 +3581,31 @@ function App() {
         </button>
 
         <div className="window-controls">
-          <button onClick={handleMinimize} title="Minimize">─</button>
-          <button onClick={handleMaximize} title="Maximize">□</button>
-          <button onClick={handleClose} className="close" title="Close">✕</button>
+          <button onClick={handleMinimize} title="Minimize" aria-label="Minimize">
+            <svg className="window-control-icon" viewBox="0 0 12 12" aria-hidden="true">
+              <path d="M1 6.5h10" />
+            </svg>
+          </button>
+          <button
+            onClick={handleMaximize}
+            title={isMaximized ? 'Restore Down' : 'Maximize'}
+            aria-label={isMaximized ? 'Restore Down' : 'Maximize'}
+          >
+            {isMaximized ? (
+              <svg className="window-control-icon" viewBox="0 0 12 12" aria-hidden="true">
+                <path d="M3.5 3.5h7v7h-7zM1.5 8.5v-7h7" />
+              </svg>
+            ) : (
+              <svg className="window-control-icon" viewBox="0 0 12 12" aria-hidden="true">
+                <rect x="1.5" y="1.5" width="9" height="9" />
+              </svg>
+            )}
+          </button>
+          <button onClick={handleClose} className="close" title="Close" aria-label="Close">
+            <svg className="window-control-icon" viewBox="0 0 12 12" aria-hidden="true">
+              <path d="m1.5 1.5 9 9m0-9-9 9" />
+            </svg>
+          </button>
         </div>
       </div>
 

--- a/packages/ui/src/components/CategoryStrip.tsx
+++ b/packages/ui/src/components/CategoryStrip.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useLiveQuery } from '../hooks/useSqliteLiveQuery';
 import { useCategoriesBySource, type CategoryWithCount, type SourceWithCategories } from '../hooks/useChannels';
@@ -35,14 +35,21 @@ function parseCategoryIds(raw: string | string[] | number[] | undefined): string
   return [String(raw)];
 }
 
+const CategoryStripVisibilityContext = createContext(true);
+
 // Component that detects text overflow and only scrolls when necessary
 function ScrollingText({ children, className }: { children: React.ReactNode; className?: string }) {
   const textRef = useRef<HTMLSpanElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
+  const resizeActive = useContext(CategoryStripVisibilityContext);
 
   useEffect(() => {
     const element = textRef.current;
     if (!element) return;
+    if (!resizeActive) {
+      setIsOverflowing(false);
+      return;
+    }
 
     const checkOverflow = () => {
       // Check if text overflows its container
@@ -70,7 +77,7 @@ function ScrollingText({ children, className }: { children: React.ReactNode; cla
       timeouts.forEach(clearTimeout);
       window.removeEventListener('resize', handleResize);
     };
-  }, [children]);
+  }, [children, resizeActive]);
 
   return (
     <span 
@@ -980,6 +987,7 @@ export function CategoryStrip({ selectedCategoryId, onSelectCategory, visible, o
   );
 
   return (
+    <CategoryStripVisibilityContext.Provider value={visible}>
     <>
       <div className={`category-strip ${visible ? 'visible' : 'hidden'}`}>
         {/* Resizer Handle */}
@@ -1659,6 +1667,7 @@ export function CategoryStrip({ selectedCategoryId, onSelectCategory, visible, o
         </button>
       )}
     </>
+    </CategoryStripVisibilityContext.Provider>
   );
 }
 

--- a/packages/ui/src/components/ChannelPanel.tsx
+++ b/packages/ui/src/components/ChannelPanel.tsx
@@ -1671,6 +1671,9 @@ export function ChannelPanel({
   useEffect(() => {
     if (!visible) return;
     // if (!window.mpv) return; // Bridge handles this
+    let rafId: number | null = null;
+    let lastMainGeometry = '';
+    const lastSecondaryGeometries = new Map<2 | 3 | 4, string>();
 
     const updateVideoPosition = () => {
       // Use last known channel ID if current selection is null but we have one cached
@@ -1718,8 +1721,12 @@ export function ChannelPanel({
       const sy = Math.round(rect.top * d);
       const sw = Math.round(rect.width * d);
       const sh = Math.round(rect.height * d);
+      const nextMainGeometry = `${sx}:${sy}:${sw}:${sh}`;
 
-      invoke('mpv_set_geometry', { x: sx, y: sy, width: sw, height: sh }).catch(() => {});
+      if (nextMainGeometry !== lastMainGeometry) {
+        lastMainGeometry = nextMainGeometry;
+        invoke('mpv_set_geometry', { x: sx, y: sy, width: sw, height: sh }).catch(() => {});
+      }
 
       // Reposition secondary MPV slots inside EPG preview container cells (only if engineMode is 'mpv')
       if (multiviewEngineMode === 'mpv') {
@@ -1727,15 +1734,17 @@ export function ChannelPanel({
         const shouldHideSecondaries = isEpgModalOpen || showSettingsPopup;
 
         const secondaryIds: (2 | 3 | 4)[] = [2, 3, 4];
-        secondaryIds.forEach(async (slotId) => {
+        secondaryIds.forEach((slotId) => {
           const slot = multiviewSlots.find((s) => s.id === slotId);
           const active = slot?.active ?? false;
-          
-          const { invoke } = await import('@tauri-apps/api/core');
 
           // If a slot is not active, or if we want to hide them (because a modal/settings is open):
           if (!active || shouldHideSecondaries) {
-            invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
+            const hiddenGeometry = '-10000:-10000:1:1';
+            if (lastSecondaryGeometries.get(slotId) !== hiddenGeometry) {
+              lastSecondaryGeometries.set(slotId, hiddenGeometry);
+              invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
+            }
             return;
           }
 
@@ -1743,13 +1752,21 @@ export function ChannelPanel({
           const id = `epg-slot-container-${slotId}`;
           const el = document.getElementById(id);
           if (!el) {
-            invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
+            const hiddenGeometry = '-10000:-10000:1:1';
+            if (lastSecondaryGeometries.get(slotId) !== hiddenGeometry) {
+              lastSecondaryGeometries.set(slotId, hiddenGeometry);
+              invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
+            }
             return;
           }
 
           const cellRect = el.getBoundingClientRect();
           if (cellRect.width === 0 || cellRect.height === 0) {
-            invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
+            const hiddenGeometry = '-10000:-10000:1:1';
+            if (lastSecondaryGeometries.get(slotId) !== hiddenGeometry) {
+              lastSecondaryGeometries.set(slotId, hiddenGeometry);
+              invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
+            }
             return;
           }
 
@@ -1758,14 +1775,26 @@ export function ChannelPanel({
           const sy = Math.round(cellRect.top * d);
           const sw = Math.round(cellRect.width * d);
           const sh = Math.round(cellRect.height * d);
+          const nextSlotGeometry = `${sx}:${sy}:${sw}:${sh}`;
 
-          invoke('multiview_reposition_slot', { slotId, x: sx, y: sy, width: sw, height: sh }).catch(() => {});
+          if (lastSecondaryGeometries.get(slotId) !== nextSlotGeometry) {
+            lastSecondaryGeometries.set(slotId, nextSlotGeometry);
+            invoke('multiview_reposition_slot', { slotId, x: sx, y: sy, width: sw, height: sh }).catch(() => {});
+          }
         });
       }
     };
 
+    const scheduleVideoPositionUpdate = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateVideoPosition();
+      });
+    };
+
     const observer = new ResizeObserver(() => {
-      requestAnimationFrame(updateVideoPosition);
+      scheduleVideoPositionUpdate();
     });
 
     if (previewRef.current) {
@@ -1775,7 +1804,7 @@ export function ChannelPanel({
 
     // Listen for window resize events to keep the MPV window aligned when layout shifts
     const handleWindowResize = () => {
-      requestAnimationFrame(updateVideoPosition);
+      scheduleVideoPositionUpdate();
     };
     window.addEventListener('resize', handleWindowResize);
 
@@ -1786,7 +1815,7 @@ export function ChannelPanel({
     import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
       const appWindow = getCurrentWindow();
       appWindow.onMoved(() => {
-        updateVideoPosition();
+        scheduleVideoPositionUpdate();
       }).then((unlisten) => {
         if (disposed) unlisten();
         else unlistenMove = unlisten;
@@ -1812,6 +1841,7 @@ export function ChannelPanel({
       observer.disconnect();
       window.removeEventListener('resize', handleWindowResize);
       if (unlistenMove) unlistenMove();
+      if (rafId !== null) cancelAnimationFrame(rafId);
       cancelAnimationFrame(animationFrameId);
       // NOTE: Do NOT call onPreviewVideoRectChange(null) here.
       // This cleanup runs on every dependency change (e.g. currentLayout/showMultiviewGrid),
@@ -1822,8 +1852,7 @@ export function ChannelPanel({
 
       if (multiviewEngineMode === 'mpv') {
         const secondaryIds: (2 | 3 | 4)[] = [2, 3, 4];
-        secondaryIds.forEach(async (slotId) => {
-          const { invoke } = await import('@tauri-apps/api/core');
+        secondaryIds.forEach((slotId) => {
           invoke('multiview_reposition_slot', { slotId, x: -10000, y: -10000, width: 1, height: 1 }).catch(() => {});
         });
       }

--- a/packages/ui/src/components/sports/SportsHub.tsx
+++ b/packages/ui/src/components/sports/SportsHub.tsx
@@ -181,6 +181,9 @@ export function SportsHub({
   // Handle Video Resizing for Preview Mode via ResizeObserver explicitly when component mounts
   useEffect(() => {
     let isSyncing = false;
+    let queuedUpdate = false;
+    let rafId: number | null = null;
+    let lastGeometry = '';
     const isReady = visible === undefined ? true : (visible && transitionCompleted);
 
     const updateVideoPosition = async () => {
@@ -227,6 +230,14 @@ export function SportsHub({
       const sy = Math.round(rect.top * d);
       const sw = Math.round(rect.width * d);
       const sh = Math.round(rect.height * d);
+      const nextGeometry = `${sx}:${sy}:${sw}:${sh}`;
+
+      if (nextGeometry === lastGeometry) {
+        isSyncing = false;
+        return;
+      }
+
+      lastGeometry = nextGeometry;
 
       invoke('mpv_set_geometry', { x: sx, y: sy, width: sw, height: sh })
         .catch((e) => {
@@ -234,11 +245,27 @@ export function SportsHub({
         })
         .finally(() => {
           isSyncing = false;
+          if (queuedUpdate) {
+            queuedUpdate = false;
+            updateVideoPosition();
+          }
         });
     };
 
+    const scheduleVideoPositionUpdate = () => {
+      if (isSyncing) {
+        queuedUpdate = true;
+        return;
+      }
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateVideoPosition();
+      });
+    };
+
     const observer = new ResizeObserver(() => {
-      requestAnimationFrame(updateVideoPosition);
+      scheduleVideoPositionUpdate();
     });
 
     if (previewRef.current) {
@@ -248,7 +275,7 @@ export function SportsHub({
 
     // Listen for window resize events to keep the MPV window aligned when layout shifts
     const handleWindowResize = () => {
-      requestAnimationFrame(updateVideoPosition);
+      scheduleVideoPositionUpdate();
     };
     window.addEventListener('resize', handleWindowResize);
 
@@ -259,7 +286,7 @@ export function SportsHub({
     import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
       const appWindow = getCurrentWindow();
       appWindow.onMoved(() => {
-        updateVideoPosition();
+        scheduleVideoPositionUpdate();
       }).then((unlisten) => {
         if (disposed) unlisten();
         else unlistenMove = unlisten;
@@ -286,6 +313,7 @@ export function SportsHub({
       observer.disconnect();
       window.removeEventListener('resize', handleWindowResize);
       if (unlistenMove) unlistenMove();
+      if (rafId !== null) cancelAnimationFrame(rafId);
       cancelAnimationFrame(animationFrameId);
       onPreviewVideoRectChange?.(null);
     };

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ import { DEFAULT_SHORTCUTS } from '../constants/shortcuts';
 import type { StoredChannel } from '../db';
 import type { LayoutMode } from './useMultiview';
 import type { View } from './useNavigation';
+import { Bridge } from '../services/tauri-bridge';
 
 export interface UseKeyboardShortcutsOptions {
     // --- Current state values (accessed via latest ref pattern) ---
@@ -69,7 +70,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions): void
     latestRefs.current = options;
 
     useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
+        const handleKeyDown = async (e: KeyboardEvent) => {
             // Don't handle shortcuts when typing in inputs
             if (
                 e.target instanceof HTMLInputElement ||
@@ -219,6 +220,16 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions): void
                     titleBarSearchRef.current.focus();
                 }
             } else if (matches('close', e.key)) {
+                e.preventDefault();
+                try {
+                    if (await Bridge.isFullscreen()) {
+                        await Bridge.toggleFullscreen();
+                        return;
+                    }
+                } catch (err) {
+                    console.error('[KeyboardShortcuts] Failed to exit fullscreen on Escape:', err);
+                }
+
                 // Close settings popup first if open
                 if (showSettingsPopup) {
                     setShowSettingsPopup(false);

--- a/packages/ui/src/hooks/usePipMode.ts
+++ b/packages/ui/src/hooks/usePipMode.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { getCurrentWindow, currentMonitor, LogicalSize, LogicalPosition } from '@tauri-apps/api/window';
+import { invoke } from '@tauri-apps/api/core';
+import { Bridge, type AspectRatioMode } from '../services/tauri-bridge';
 
 interface WindowSnapshot {
   width: number;
@@ -42,7 +44,19 @@ function savePipState(s: PipSavedState) {
   } catch {}
 }
 
-export function usePipMode() {
+async function resolvePipRatio(mode: AspectRatioMode): Promise<number | null> {
+  if (mode === '16:9') return 16 / 9;
+  if (mode === '4:3') return 4 / 3;
+  if (mode === 'fit') {
+    try {
+      const aspect = Number(await Bridge.getProperty('video-params/aspect'));
+      if (Number.isFinite(aspect) && aspect > 0) return aspect;
+    } catch {}
+  }
+  return null;
+}
+
+export function usePipMode(aspectMode: AspectRatioMode) {
   const [pipMode, setPipMode] = useState(false);
   const [pipControlsVisible, setPipControlsVisible] = useState(false);
   const snap = useRef<WindowSnapshot | null>(null);
@@ -116,16 +130,21 @@ export function usePipMode() {
       await w.setSize(new LogicalSize(pipW, pipH));
       await w.setPosition(new LogicalPosition(tx, ty));
       await w.setAlwaysOnTop(true);
+      await invoke('set_pip_aspect_lock', { ratio: await resolvePipRatio(aspectMode) });
       setPipMode(true);
       setPipControlsVisible(true);
     } catch (e) {
       console.error('[PiP] enter failed:', e);
     }
-  }, []);
+  }, [aspectMode]);
 
   const exitPip = useCallback(async () => {
     try {
       const w = getCurrentWindow();
+
+      await invoke('set_pip_aspect_lock', { ratio: null }).catch(e => {
+        console.error('[PiP] aspect lock disable failed:', e);
+      });
 
       const [innerSize, pos, sf] = await Promise.all([
         w.innerSize(),
@@ -164,6 +183,17 @@ export function usePipMode() {
       console.error('[PiP] exit failed:', e);
     }
   }, []);
+
+  useEffect(() => {
+    if (!pipMode) return;
+    let cancelled = false;
+    resolvePipRatio(aspectMode)
+      .then(ratio => {
+        if (!cancelled) return invoke('set_pip_aspect_lock', { ratio });
+      })
+      .catch(e => console.error('[PiP] aspect lock update failed:', e));
+    return () => { cancelled = true; };
+  }, [pipMode, aspectMode]);
 
   const togglePip = useCallback(async () => {
     if (pipMode) await exitPip();

--- a/packages/ui/src/hooks/useWindowManager.ts
+++ b/packages/ui/src/hooks/useWindowManager.ts
@@ -1,19 +1,59 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { Bridge } from '../services/tauri-bridge';
 
 export interface WindowManagerState {
   handleMinimize: () => void;
   handleMaximize: () => void;
   handleClose: () => void;
+  isMaximized: boolean;
 }
 
 export function useWindowManager(): WindowManagerState {
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    const appWindow = getCurrentWindow();
+    let disposed = false;
+    let updateTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const updateMaximizedState = async () => {
+      const maximized = await appWindow.isMaximized();
+      if (!disposed) setIsMaximized(maximized);
+    };
+
+    updateMaximizedState().catch(() => {});
+    const unlistenPromise = appWindow.onResized(() => {
+      if (updateTimer) clearTimeout(updateTimer);
+      updateTimer = setTimeout(() => {
+        updateTimer = null;
+        updateMaximizedState().catch(() => {});
+      }, 50);
+    });
+
+    return () => {
+      disposed = true;
+      if (updateTimer) clearTimeout(updateTimer);
+      unlistenPromise.then(unlisten => unlisten()).catch(() => {});
+    };
+  }, []);
+
   const handleMinimize = useCallback(() => {
     Bridge.minimize();
   }, []);
 
-  const handleMaximize = useCallback(() => {
-    Bridge.toggleMaximize();
+  const handleMaximize = useCallback(async () => {
+    try {
+      if (await Bridge.isFullscreen()) {
+        await Bridge.setFullscreen(false, { restoreMaximized: false });
+        setIsMaximized(false);
+        return;
+      }
+      await Bridge.toggleMaximize();
+      setIsMaximized(await Bridge.isMaximized());
+    } catch (err) {
+      console.error('[WindowManager] maximize failed:', err);
+    }
   }, []);
 
   const handleClose = useCallback(() => {
@@ -24,5 +64,6 @@ export function useWindowManager(): WindowManagerState {
     handleMinimize,
     handleMaximize,
     handleClose,
+    isMaximized,
   };
 }

--- a/packages/ui/src/services/tauri-bridge.ts
+++ b/packages/ui/src/services/tauri-bridge.ts
@@ -22,6 +22,11 @@ type UnlistenFn = () => void;
 let windowSyncListeners: { move?: UnlistenFn; resize?: UnlistenFn; focus?: UnlistenFn; close?: UnlistenFn } = {};
 let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let focusSyncTimer: ReturnType<typeof setTimeout> | null = null;
+let fullscreenRestoreMaximized: boolean | null = null;
+
+function delay(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 // Callback for app close event
 let onAppCloseCallback: (() => void) | null = null;
@@ -462,7 +467,63 @@ export const Bridge = {
     },
 
     async toggleFullscreen() {
-        return invoke('mpv_toggle_fullscreen');
+        const appWindow = getCurrentWindow();
+        const isFullscreen = await appWindow.isFullscreen();
+
+        if (!isFullscreen) {
+            fullscreenRestoreMaximized = await appWindow.isMaximized();
+            await invoke('mpv_toggle_fullscreen', { restoreToMaximized: false });
+            return;
+        }
+
+        if (fullscreenRestoreMaximized) {
+            await invoke('mpv_toggle_fullscreen', { restoreToMaximized: true });
+            fullscreenRestoreMaximized = null;
+            return;
+        }
+        await invoke('mpv_toggle_fullscreen', { restoreToMaximized: false });
+        fullscreenRestoreMaximized = null;
+    },
+
+    async isFullscreen() {
+        const appWindow = getCurrentWindow();
+        return appWindow.isFullscreen();
+    },
+
+    async setFullscreen(fullscreen: boolean, options?: { restoreMaximized?: boolean }) {
+        const appWindow = getCurrentWindow();
+        const isFullscreen = await appWindow.isFullscreen();
+        if (isFullscreen === fullscreen) {
+            return;
+        }
+
+        if (fullscreen) {
+            fullscreenRestoreMaximized = await appWindow.isMaximized();
+            await invoke('mpv_toggle_fullscreen', { restoreToMaximized: false });
+            return;
+        }
+
+        const shouldRestoreMaximized = options?.restoreMaximized ?? fullscreenRestoreMaximized === true;
+        fullscreenRestoreMaximized = null;
+
+        if (shouldRestoreMaximized) {
+            await invoke('mpv_toggle_fullscreen', { restoreToMaximized: shouldRestoreMaximized });
+            return;
+        }
+
+        await invoke('mpv_toggle_fullscreen', { restoreToMaximized: shouldRestoreMaximized });
+
+        if (!fullscreen) {
+            await delay(50);
+            if (await appWindow.isMaximized()) {
+                await appWindow.unmaximize();
+            }
+        }
+    },
+
+    async isMaximized() {
+        const appWindow = getCurrentWindow();
+        return appWindow.isMaximized();
     },
 
     async getTrackList(): Promise<any[]> {

--- a/packages/ui/src/themes.css
+++ b/packages/ui/src/themes.css
@@ -3488,4 +3488,8 @@ body.is-resizing * {
   animation: none !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+  will-change: auto !important;
 }


### PR DESCRIPTION
 ## Summary

This PR improves PiP and general window behavior on Windows.

- Adds native aspect-ratio locking for PiP:
  - **Fit** follows the video’s actual aspect ratio.
  - **16:9** and **4:3** remain locked while resizing.
  - **Fill** and **Stretch** remain freely resizable in all directions.
- Greatly improves live resizing responsiveness so the window follows the cursor more closely and stops promptly after release. 
_Explanation: Previously, there was a lot of lag on some systems when resizing the window. This change makes the behavior more robust, especially on lower end systems._
- Reduces unnecessary visual updates during resizing.
- Fixes fullscreen exit and maximized state restoration behavior to match more familiar desktop media player behavior to match user expectations.
- Ensures saved startup window dimensions fit the current monitor. 
_Explanation: Previously, when using multiple monitors with mixed DPI, some issues were encountered with window dimensions, making it very difficult to recover the window._
- Replaces the title bar window controls with normalized Windows style icons (minimize, responsive maximize/restore, exit).
- Shows the **Restore Down** icon when the window is maximized as mentioned above.

## Testing

Tested on Windows in both development and (unsigned) release builds, on both 1080p and 4K monitors at 16:9 aspect ratio. Tests include:

- PiP resizing from horizontal, vertical, and diagonal edges.
- All PiP aspect modes.
- PiP entry and exit.
- Resizing with and without video playing.
- Fullscreen entry and exit.
- Maximizing and restoring the window.
- Startup window sizing.